### PR TITLE
Documenting use of librarian-puppet `install` rather than `update`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,5 @@ Stands up a Linux Apache MySQL PHP environment using Vagrant, Puppet and Hiera.
 ## Installation
 
 * Clone this repo into your desired folder
-* Run "librarian-puppet update"
+* Run "librarian-puppet install"
 * Run "vagrant up"


### PR DESCRIPTION
Install should install a set of known working versions while `update` could update to newer releases that are busted.
